### PR TITLE
feat(experimental): native share menu using web share API

### DIFF
--- a/src/components/NativeShareBtn.tsx
+++ b/src/components/NativeShareBtn.tsx
@@ -1,0 +1,16 @@
+import { IconButton } from '@chakra-ui/react'
+import React from 'react'
+import { AiOutlineShareAlt } from 'react-icons/ai'
+import { useWebShare } from '../hooks'
+
+type Props = {
+  title: string
+  text: string
+}
+
+export const NativeShareBtn: React.FC<Props> = ({ title, text }) => {
+  const { canShare, onShare } = useWebShare(title, text)
+  return canShare ? (
+    <IconButton aria-label="share" icon={<AiOutlineShareAlt />} variant="link" onClick={onShare} />
+  ) : null
+}

--- a/src/components/NativeShareBtn.tsx
+++ b/src/components/NativeShareBtn.tsx
@@ -1,15 +1,11 @@
 import { IconButton } from '@chakra-ui/react'
 import React from 'react'
 import { AiOutlineShareAlt } from 'react-icons/ai'
+
 import { useWebShare } from '../hooks'
 
-type Props = {
-  title: string
-  text: string
-}
-
-export const NativeShareBtn: React.FC<Props> = ({ title, text }) => {
-  const { canShare, onShare } = useWebShare(title, text)
+export const NativeShareBtn: React.FC = () => {
+  const { canShare, onShare } = useWebShare()
   return canShare ? (
     <IconButton aria-label="share" icon={<AiOutlineShareAlt />} variant="link" onClick={onShare} />
   ) : null

--- a/src/containers/AppleDailyArticle/index.tsx
+++ b/src/containers/AppleDailyArticle/index.tsx
@@ -75,7 +75,7 @@ export const AppleDailyArticle: React.FC<Props> = ({ article }) => {
         <Text color="gray.500" my={2}>
           蘋果日報 {article.publishTimestamp ? getFullFormatFromTs(article.publishTimestamp) : '未知'}
         </Text>
-        <NativeShareBtn title={article.title} text={desc} />
+        <NativeShareBtn />
       </Flex>
       <Box my={2}>
         {filterTag(article.tags || []).map((tag, index) => (

--- a/src/containers/AppleDailyArticle/index.tsx
+++ b/src/containers/AppleDailyArticle/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Heading, Text, Tag, Fade } from '@chakra-ui/react'
+import { Box, Divider, Heading, Text, Tag, Fade, Flex } from '@chakra-ui/react'
 import React from 'react'
 
 import { HeaderBlock, HTMLBlock, ImageBlock, ListBlock, TableBlock, VideoBlock } from '../../components/ArticleBlocks'
@@ -9,6 +9,7 @@ import { isEmpty, trim } from 'ramda'
 import { getFullFormatFromTs } from '../../utils/date'
 import { Carousel } from '../../components/Carousel'
 import { useWindowScroll } from 'react-use'
+import { NativeShareBtn } from '../../components/NativeShareBtn'
 
 type Props = {
   article: Article
@@ -70,9 +71,12 @@ export const AppleDailyArticle: React.FC<Props> = ({ article }) => {
         </Fade>
       </Box>
 
-      <Text color="gray.500" my={2}>
-        蘋果日報 {article.publishTimestamp ? getFullFormatFromTs(article.publishTimestamp) : '未知'}
-      </Text>
+      <Flex direction="row">
+        <Text color="gray.500" my={2}>
+          蘋果日報 {article.publishTimestamp ? getFullFormatFromTs(article.publishTimestamp) : '未知'}
+        </Text>
+        <NativeShareBtn title={article.title} text={desc} />
+      </Flex>
       <Box my={2}>
         {filterTag(article.tags || []).map((tag, index) => (
           <Tag key={index} mr={2} borderRadius="sm" bg="brand.400">

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useArticlesQuery'
+export * from './useWebShare'

--- a/src/hooks/useWebShare.ts
+++ b/src/hooks/useWebShare.ts
@@ -1,4 +1,4 @@
-export function useWebShare(title: string, text: string) {
+export function useWebShare() {
   const onShare = () => {
     if (navigator.share) {
       let url = document.location.href
@@ -8,8 +8,7 @@ export function useWebShare(title: string, text: string) {
       }
       navigator
         .share({
-          title: title,
-          text: text,
+          title: document.querySelector('title')?.textContent || '',
           url: url,
         })
         .then(() => console.log('Successful share'))

--- a/src/hooks/useWebShare.ts
+++ b/src/hooks/useWebShare.ts
@@ -1,0 +1,22 @@
+export function useWebShare(title: string, text: string) {
+  const onShare = () => {
+    if (navigator.share) {
+      let url = document.location.href
+      const canonicalElement: HTMLLinkElement | null = document.querySelector('link[rel=canonical]')
+      if (canonicalElement !== null) {
+        url = canonicalElement.href
+      }
+      navigator
+        .share({
+          title: title,
+          text: text,
+          url: url,
+        })
+        .then(() => console.log('Successful share'))
+        .catch(error => console.log('Error sharing', error))
+    }
+  }
+
+  const canShare = typeof window !== 'undefined' && !!navigator.share
+  return { canShare, onShare }
+}


### PR DESCRIPTION
It is just a PoC, need to test. fix #5 

* https://css-tricks.com/how-to-use-the-web-share-api/
* https://caniuse.com/?search=share
* https://web.dev/web-share/

Can I Use: Tracked mobile 92.9% 

_Update:_
Tested work on iOS Safari, Chrome, DuckDuckGo, Telegram, PWA